### PR TITLE
Add Docker server mode option

### DIFF
--- a/Editor/UnityBridge/McpUnityEditorWindow.cs
+++ b/Editor/UnityBridge/McpUnityEditorWindow.cs
@@ -130,9 +130,17 @@ namespace McpUnity.Unity
                 settings.AutoStartServer = autoStartServer;
                 settings.SaveSettings();
             }
-            
+
             EditorGUILayout.Space();
-            
+
+            // Server run mode
+            McpUnitySettings.ServerMode newMode = (McpUnitySettings.ServerMode)EditorGUILayout.EnumPopup(new GUIContent("Server Mode", "Run the Node.js server locally or inside a Docker container"), settings.RunMode);
+            if (newMode != settings.RunMode)
+            {
+                settings.RunMode = newMode;
+                settings.SaveSettings();
+            }
+
             // Enable info logs toggle
             bool enableInfoLogs = EditorGUILayout.Toggle(new GUIContent("Enable Info Logs", "Show informational logs in the Unity console"), settings.EnableInfoLogs);
             if (enableInfoLogs != settings.EnableInfoLogs)

--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -29,6 +29,7 @@ namespace McpUnity.Unity
         private CancellationTokenSource _cts;
         private TestRunnerService _testRunnerService;
         private ConsoleLogsService _consoleLogsService;
+        private Process _nodeProcess;
 
         /// <summary>
         /// Static constructor that gets called when Unity loads due to InitializeOnLoad attribute
@@ -88,9 +89,17 @@ namespace McpUnity.Unity
         public void StartServer()
         {
             if (IsListening) return;
-            
+
             try
             {
+                if (McpUnitySettings.Instance.RunMode == McpUnitySettings.ServerMode.Docker)
+                {
+                    StartDockerServer();
+                }
+                else
+                {
+                    StartLocalNodeServer();
+                }
                 // Create a new WebSocket server
                 _webSocketServer = new WebSocketServer($"ws://localhost:{McpUnitySettings.Instance.Port}");
                 // Add the MCP service endpoint with a handler that references this server
@@ -117,7 +126,16 @@ namespace McpUnity.Unity
             try
             {
                 _webSocketServer?.Stop();
-                
+
+                if (McpUnitySettings.Instance.RunMode == McpUnitySettings.ServerMode.Docker)
+                {
+                    StopDockerServer();
+                }
+                else
+                {
+                    StopLocalNodeServer();
+                }
+
                 McpLogger.LogInfo("WebSocket server stopped");
             }
             catch (Exception ex)
@@ -167,6 +185,99 @@ namespace McpUnity.Unity
             {
                 McpUtils.RunNpmCommand("run build", serverPath);
             }
+        }
+
+        /// <summary>
+        /// Build the Docker image and start the container if necessary.
+        /// </summary>
+        public void StartDockerServer()
+        {
+            string serverPath = McpUtils.GetServerPath();
+            if (string.IsNullOrEmpty(serverPath) || !Directory.Exists(serverPath))
+            {
+                McpLogger.LogError($"Server path not found or invalid: {serverPath}. Cannot start Docker container.");
+                return;
+            }
+
+            McpUtils.BuildDockerImage(serverPath);
+            McpUtils.StartDockerContainer(serverPath, "mcp-unity-server");
+        }
+
+        /// <summary>
+        /// Start the Node.js server locally using the installed Node runtime.
+        /// </summary>
+        public void StartLocalNodeServer()
+        {
+            string serverPath = McpUtils.GetServerPath();
+            if (string.IsNullOrEmpty(serverPath) || !Directory.Exists(serverPath))
+            {
+                McpLogger.LogError($"Server path not found or invalid: {serverPath}. Cannot start Node.js server.");
+                return;
+            }
+
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                FileName = "node",
+                Arguments = Path.Combine(serverPath, "build", "index.js"),
+                WorkingDirectory = serverPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            try
+            {
+                _nodeProcess = Process.Start(startInfo);
+                if (_nodeProcess == null)
+                {
+                    McpLogger.LogError("Failed to start Node.js process.");
+                }
+            }
+            catch (Exception ex)
+            {
+                McpLogger.LogError($"Failed to start Node.js server: {ex.Message}");
+            }
+        }
+
+        [MenuItem("Tools/MCP Unity/Start Docker Server")]
+        private static void MenuStartDockerServer()
+        {
+            Instance.StartDockerServer();
+        }
+
+        /// <summary>
+        /// Stop the Docker container if it is running.
+        /// </summary>
+        public void StopDockerServer()
+        {
+            McpUtils.StopDockerContainer("mcp-unity-server");
+        }
+
+        /// <summary>
+        /// Stop the locally running Node.js server.
+        /// </summary>
+        public void StopLocalNodeServer()
+        {
+            if (_nodeProcess != null && !_nodeProcess.HasExited)
+            {
+                try
+                {
+                    _nodeProcess.Kill();
+                    _nodeProcess.WaitForExit();
+                }
+                catch (Exception ex)
+                {
+                    McpLogger.LogError($"Error stopping Node.js server: {ex.Message}");
+                }
+            }
+            _nodeProcess = null;
+        }
+
+        [MenuItem("Tools/MCP Unity/Stop Docker Server")]
+        private static void MenuStopDockerServer()
+        {
+            Instance.StopDockerServer();
         }
         
         /// <summary>

--- a/Editor/UnityBridge/McpUnityServer.cs
+++ b/Editor/UnityBridge/McpUnityServer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using UnityEngine;
 using UnityEditor;
 using McpUnity.Tools;
 using McpUnity.Resources;
@@ -192,7 +191,7 @@ namespace McpUnity.Unity
         /// </summary>
         public void StartDockerServer()
         {
-            string serverPath = McpUtils.GetServerPath();
+            var serverPath = McpUtils.GetServerPath();
             if (string.IsNullOrEmpty(serverPath) || !Directory.Exists(serverPath))
             {
                 McpLogger.LogError($"Server path not found or invalid: {serverPath}. Cannot start Docker container.");
@@ -200,7 +199,16 @@ namespace McpUnity.Unity
             }
 
             McpUtils.BuildDockerImage(serverPath);
-            McpUtils.StartDockerContainer(serverPath, "mcp-unity-server");
+            McpUtils.StartDockerContainer(serverPath, McpUtils.DockerContainerName, McpUnitySettings.Instance.Port);
+        }
+
+        /// <summary>
+        /// Stop the Docker container if it is running.
+        /// </summary>
+        public void StopDockerServer()
+        {
+            var serverPath = McpUtils.GetServerPath();
+            McpUtils.StopDockerContainer(serverPath, McpUtils.DockerContainerName);
         }
 
         /// <summary>
@@ -228,11 +236,18 @@ namespace McpUnity.Unity
 
             try
             {
-                _nodeProcess = Process.Start(startInfo);
-                if (_nodeProcess == null)
+                _nodeProcess = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+                _nodeProcess.OutputDataReceived += OnNodeProcessOutputDataReceived;
+                _nodeProcess.ErrorDataReceived += OnNodeProcessErrorDataReceived;
+                _nodeProcess.Exited += OnNodeProcessExited;
+
+                if (!_nodeProcess.Start())
                 {
                     McpLogger.LogError("Failed to start Node.js process.");
+                    return;
                 }
+                _nodeProcess.BeginOutputReadLine();
+                _nodeProcess.BeginErrorReadLine();
             }
             catch (Exception ex)
             {
@@ -240,18 +255,34 @@ namespace McpUnity.Unity
             }
         }
 
+        private void OnNodeProcessOutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+            {
+                McpLogger.LogInfo($"[Node.js] {e.Data}");   
+            }
+        }
+
+        private void OnNodeProcessErrorDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+            {
+                McpLogger.LogError($"[Node.js] {e.Data}");   
+            }
+        }
+
+        private void OnNodeProcessExited(object sender, EventArgs e)
+        {
+            if (_nodeProcess != null)
+            {
+                McpLogger.LogInfo($"Node.js process exited with code {_nodeProcess.ExitCode}");
+            }
+        }
+
         [MenuItem("Tools/MCP Unity/Start Docker Server")]
         private static void MenuStartDockerServer()
         {
             Instance.StartDockerServer();
-        }
-
-        /// <summary>
-        /// Stop the Docker container if it is running.
-        /// </summary>
-        public void StopDockerServer()
-        {
-            McpUtils.StopDockerContainer("mcp-unity-server");
         }
 
         /// <summary>

--- a/Editor/UnityBridge/McpUnitySettings.cs
+++ b/Editor/UnityBridge/McpUnitySettings.cs
@@ -37,6 +37,15 @@ namespace McpUnity.Unity
         [Tooltip("Optional: Full path to the npm executable (e.g., /Users/user/.asdf/shims/npm or C:\\path\\to\\npm.cmd). If not set, 'npm' from the system PATH will be used.")]
         public string NpmExecutablePath = string.Empty;
 
+        public enum ServerMode
+        {
+            Local,
+            Docker
+        }
+
+        [Tooltip("Choose whether to run the MCP server locally with Node.js or inside a Docker container")]
+        public ServerMode RunMode = ServerMode.Local;
+
         /// <summary>
         /// Singleton instance of settings
         /// </summary>

--- a/Editor/Utils/McpUtils.cs
+++ b/Editor/Utils/McpUtils.cs
@@ -17,6 +17,9 @@ namespace McpUnity.Utils
     /// </summary>
     public static class McpUtils
     {
+        // Shared constants for container name
+        public const string DockerContainerName = "mcp-unity-server";
+
         /// <summary>
         /// Generates the MCP configuration JSON to setup the Unity MCP server in different AI Clients
         /// </summary>
@@ -395,7 +398,7 @@ namespace McpUnity.Utils
             else
             {
                 startInfo.FileName = "/bin/bash";
-                startInfo.Arguments = $"-c \"docker {arguments}\"";
+                startInfo.Arguments = $"-c -l \"docker {arguments}\"";
             }
 
             try
@@ -452,22 +455,22 @@ namespace McpUnity.Utils
         /// <summary>
         /// Starts the docker container if it is not already running.
         /// </summary>
-        public static void StartDockerContainer(string workingDirectory, string containerName)
+        public static void StartDockerContainer(string workingDirectory, string containerName, int port)
         {
-            if (!IsDockerContainerRunning(containerName))
+            if (!IsDockerContainerRunning(workingDirectory, containerName))
             {
-                RunDockerCommand($"run -d --rm --name {containerName} -p 8090:8090 mcp-unity-server", workingDirectory);
+                RunDockerCommand($"run -d --rm --name {containerName} -p {port}:{port} {DockerContainerName}", workingDirectory);
             }
         }
 
         /// <summary>
         /// Stops the docker container if it is running.
         /// </summary>
-        public static void StopDockerContainer(string containerName)
+        public static void StopDockerContainer(string workingDirectory, string containerName)
         {
-            if (IsDockerContainerRunning(containerName))
+            if (IsDockerContainerRunning(workingDirectory, containerName))
             {
-                RunDockerCommand($"stop {containerName}", Environment.CurrentDirectory);
+                RunDockerCommand($"stop {containerName}", workingDirectory);
             }
         }
     }

--- a/Editor/Utils/McpUtils.cs
+++ b/Editor/Utils/McpUtils.cs
@@ -368,5 +368,107 @@ namespace McpUnity.Utils
                 Debug.LogError($"[MCP Unity] Exception while running npm {arguments} in {workingDirectory}. Error: {ex.Message}");
             }
         }
+
+        /// <summary>
+        /// Runs a docker command in the specified working directory and
+        /// returns the standard output.
+        /// </summary>
+        /// <param name="arguments">Arguments to pass to docker.</param>
+        /// <param name="workingDirectory">The working directory where the docker command should be executed.</param>
+        /// <returns>The standard output of the docker command.</returns>
+        public static string RunDockerCommand(string arguments, string workingDirectory)
+        {
+            System.Diagnostics.ProcessStartInfo startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                startInfo.FileName = "cmd.exe";
+                startInfo.Arguments = $"/c docker {arguments}";
+            }
+            else
+            {
+                startInfo.FileName = "/bin/bash";
+                startInfo.Arguments = $"-c \"docker {arguments}\"";
+            }
+
+            try
+            {
+                using (var process = System.Diagnostics.Process.Start(startInfo))
+                {
+                    if (process == null)
+                    {
+                        Debug.LogError($"[MCP Unity] Failed to start docker process with arguments: {arguments} in {workingDirectory}. Process object is null.");
+                        return string.Empty;
+                    }
+
+                    string output = process.StandardOutput.ReadToEnd();
+                    string error = process.StandardError.ReadToEnd();
+
+                    process.WaitForExit();
+
+                    if (process.ExitCode == 0)
+                    {
+                        Debug.Log($"[MCP Unity] docker {arguments} completed successfully in {workingDirectory}.\n{output}");
+                    }
+                    else
+                    {
+                        Debug.LogError($"[MCP Unity] docker {arguments} failed in {workingDirectory}. Exit Code: {process.ExitCode}. Error: {error}");
+                    }
+
+                    return output;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[MCP Unity] Exception while running docker {arguments} in {workingDirectory}. Error: {ex.Message}");
+                return string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Builds the Docker image for the MCP Unity server.
+        /// </summary>
+        public static void BuildDockerImage(string workingDirectory)
+        {
+            RunDockerCommand("build -t mcp-unity-server .", workingDirectory);
+        }
+
+        /// <summary>
+        /// Checks if a docker container with the specified name is running.
+        /// </summary>
+        public static bool IsDockerContainerRunning(string containerName)
+        {
+            string output = RunDockerCommand($"ps --filter name={containerName} --format {{.Names}}", Environment.CurrentDirectory);
+            return output.Trim() == containerName;
+        }
+
+        /// <summary>
+        /// Starts the docker container if it is not already running.
+        /// </summary>
+        public static void StartDockerContainer(string workingDirectory, string containerName)
+        {
+            if (!IsDockerContainerRunning(containerName))
+            {
+                RunDockerCommand($"run -d --rm --name {containerName} -p 8090:8090 mcp-unity-server", workingDirectory);
+            }
+        }
+
+        /// <summary>
+        /// Stops the docker container if it is running.
+        /// </summary>
+        public static void StopDockerContainer(string containerName)
+        {
+            if (IsDockerContainerRunning(containerName))
+            {
+                RunDockerCommand($"stop {containerName}", Environment.CurrentDirectory);
+            }
+        }
     }
 }

--- a/Editor/Utils/McpUtils.cs
+++ b/Editor/Utils/McpUtils.cs
@@ -443,9 +443,9 @@ namespace McpUnity.Utils
         /// <summary>
         /// Checks if a docker container with the specified name is running.
         /// </summary>
-        public static bool IsDockerContainerRunning(string containerName)
+        public static bool IsDockerContainerRunning(string workingDirectory, string containerName)
         {
-            string output = RunDockerCommand($"ps --filter name={containerName} --format {{.Names}}", Environment.CurrentDirectory);
+            string output = RunDockerCommand($"ps --filter name={containerName} --format {{.Names}}", workingDirectory);
             return output.Trim() == containerName;
         }
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The following tools are available for manipulating and querying Unity scenes and
 
 ## Requirements
 - Unity 2022.3 or later - to [install the server](#install-server)
-- Node.js 18 or later - to [start the server](#start-server)
+- Node.js 18 or later **or** Docker Desktop - depending on your chosen server mode
 - npm 9 or later - to [debug the server](#debug-server)
 
 ## <a name="install-server"></a>Installation
@@ -127,8 +127,8 @@ Installing this MCP Unity Server is a multi-step process:
 ![package manager](https://github.com/user-attachments/assets/a72bfca4-ae52-48e7-a876-e99c701b0497)
 
 
-### Step 2: Install Node.js 
-> To run MCP Unity server, you'll need to have Node.js 18 or later installed on your computer:
+### Step 2a: Install Node.js (Local Mode)
+If you plan to run the server directly with Node.js, install Node.js 18 or later:
 
 <details>
 <summary><span style="font-size: 1.1em; font-weight: bold;">Windows</span></summary>
@@ -157,6 +157,16 @@ Installing this MCP Unity Server is a multi-step process:
    node --version
    ```
 </details>
+
+### Step 2b: Use Docker (Container Mode)
+Alternatively you can run the MCP server inside a Docker container.
+1. Install [Docker Desktop](https://www.docker.com/get-started/).
+2. From the project root run:
+   ```bash
+   ./build-docker.sh
+   ```
+   This builds the image and starts the container.
+3. Alternatively in Unity open **Tools > MCP Unity > Start Docker Server**.
 
 ### Step 3: Configure AI LLM Client
 
@@ -200,10 +210,14 @@ Open the MCP configuration file of your AI client (e.g. claude_desktop_config.js
 ## <a name="start-server"></a>Start Unity Editor MCP Server
 1. Open the Unity Editor
 2. Navigate to Tools > MCP Unity > Server Window
-3. Click "Start Server" to start the WebSocket server
-4. Open Claude Desktop or your AI Coding IDE (e.g. Cursor IDE, Windsurf IDE, etc.) and start executing Unity tools
+3. Choose the desired **Server Mode** (Local Node or Docker) in the Server Window.
+4. Click "Start Server" to start the WebSocket server
+   - When using Docker the container will be built and started automatically if needed.
+5. Open Claude Desktop or your AI Coding IDE (e.g. Cursor IDE, Windsurf IDE, etc.) and start executing Unity tools
    
 ![connect](https://github.com/user-attachments/assets/2e266a8b-8ba3-4902-b585-b220b11ab9a2)
+
+> The Docker container is automatically stopped when Unity closes.
 
 > When the AI client connects to the WebSocket server, it will automatically show in the green box in the window
 

--- a/Server~/Dockerfile
+++ b/Server~/Dockerfile
@@ -21,7 +21,7 @@ RUN npm run build
 # Production stage with minimal dependencies
 FROM node:18-alpine AS production
 
-# Set working directory
+# Set working directory           
 WORKDIR /app
 
 # Set production environment

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -5,11 +5,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DOCKER_IMAGE="mcp-unity-server"
 SERVER_DIR="$SCRIPT_DIR/Server~"
 
-docker build -t $DOCKER_IMAGE "$SERVER_DIR"
+docker build -t "$DOCKER_IMAGE" "$SERVER_DIR"
 # Stop any existing container with the same name
-if docker ps -a --format '{{.Names}}' | grep -q "^$DOCKER_IMAGE$"; then
-  docker stop $DOCKER_IMAGE >/dev/null 2>&1 || true
-  docker rm $DOCKER_IMAGE >/dev/null 2>&1 || true
+if docker ps -a --format '{{.Names}}' | grep -q "^$DOCKER_IMAGE\$"; then
+  docker stop "$DOCKER_IMAGE" >/dev/null 2>&1 || true
+  docker rm "$DOCKER_IMAGE" >/dev/null 2>&1 || true
 fi
 # Run the container detached
-docker run -d --rm --name $DOCKER_IMAGE -p 8090:8090 $DOCKER_IMAGE
+docker run -d --rm --name "$DOCKER_IMAGE" -p 8090:8090 "$DOCKER_IMAGE"

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Build and run the MCP Unity Node.js server Docker image
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOCKER_IMAGE="mcp-unity-server"
+SERVER_DIR="$SCRIPT_DIR/Server~"
+
+docker build -t $DOCKER_IMAGE "$SERVER_DIR"
+# Stop any existing container with the same name
+if docker ps -a --format '{{.Names}}' | grep -q "^$DOCKER_IMAGE$"; then
+  docker stop $DOCKER_IMAGE >/dev/null 2>&1 || true
+  docker rm $DOCKER_IMAGE >/dev/null 2>&1 || true
+fi
+# Run the container detached
+docker run -d --rm --name $DOCKER_IMAGE -p 8090:8090 $DOCKER_IMAGE


### PR DESCRIPTION
## Summary
- add `ServerMode` setting to choose local Node.js or Docker
- expose server mode selection in the MCP Unity Editor Window
- start/stop the Node.js process or Docker container based on setting
- document the new server mode workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685138c389fc8331b1e74aad5897b898